### PR TITLE
fix: double call of controller event in windows

### DIFF
--- a/models/Noticia.php
+++ b/models/Noticia.php
@@ -1,8 +1,8 @@
 <?php 
-require_once 'Usuario.php';
-require_once 'Correo.php';
-require_once 'Evento.php';
-require_once 'Formato.php';
+require_once '../models/Usuario.php';
+require_once '../models/Correo.php';
+require_once '../models/Evento.php';
+require_once '../models/Formato.php';
 
 class Noticia extends Conectar {
 


### PR DESCRIPTION
#39 
#35 

segun lo hablado en estos casos encontre el origen del error y es que en entornos de windows se esta interpretando la ruta del `require_one Evento.php` al `controller/evento.php` en lugar de entender que es el `models/Evento.php`

```mermaid
graph TD
    %% Linux Interpretation
    subgraph Linux
    A1["Inicio: require_once en Noticia.php"] --> B1["¿models/Evento.php existe?"]
    B1 -->|Sí| C1["Carga models/Evento.php"]
    C1 --> D1["Programa OK"]
    B1 -->|No| F1["Error: No encontrado"]
    end

    %% Windows Interpretation
    subgraph Windows
    A2["Inicio: require_once en Noticia.php"] --> B2["¿Evento.php o evento.php en directorios?"]
    B2 -->|Sí, ignora mayúsculas| C2["Carga controller/evento.php"]
    C2 --> D2["Conflicto de funciones"]
    D2 --> E2["Error"]
    end

    %% Comparison
    style A1 fill:#f9f,stroke:#333,stroke-width:2px, color:#333;
    style A2 fill:#f9f,stroke:#333,stroke-width:2px, color:#333;
    style D1 fill:#9f9,stroke:#333,stroke-width:2px, color:#333;
    style E2 fill:#f99,stroke:#333,stroke-width:2px, color:#333;

```