### PR TITLE
feat: scroll in news

### DIFF
--- a/public/js/notificaciones.js
+++ b/public/js/notificaciones.js
@@ -23,6 +23,7 @@ function addNotification(asunto, mensaje, url) {
             notificaciones.push(data);
             updateNotificationCount();
             renderNotifications();
+            scrollToTop();
         })
         .catch(error => {
             console.error('Error al guardar la notificación:', error);
@@ -44,10 +45,16 @@ document.addEventListener("DOMContentLoaded", function() {
                 notificaciones = data;
                 updateNotificationCount();
                 renderNotifications();
+                scrollToTop();
             })
             .catch(error => {
                 console.error('Error al obtener las notificaciones:', error);
             });
+    }
+
+    function scrollToTop() {
+      const notificationListElement = document.getElementById('notification-list');
+      notificationListElement.scrollTop = 0;  // Asegura que el scroll se mantenga arriba
     }
 
     setInterval(fetchNotifications, 10000);
@@ -71,6 +78,9 @@ document.addEventListener("DOMContentLoaded", function() {
         const now = new Date();
         const time_hrs_limite_live_noticia = 8;
         notificationListElement.innerHTML = '';
+
+        const notificationsToShow = notificaciones.slice(0,5);
+        
         notificaciones.forEach((notif, index) => {
             if (!notif.leido) {
                 // Mostrar notificación no leída

--- a/view/MainHeader/estiloheader.css
+++ b/view/MainHeader/estiloheader.css
@@ -77,4 +77,17 @@
     margin-right: 8px;
 }
 
+#notification-list {
+    max-height: 200px; /* Altura máxima antes de activar el scroll */
+    overflow-y: auto; /* Añade el scroll vertical */
+}
+
+#notification-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+#notification-list::-webkit-scrollbar-thumb {
+    background-color: #b18ac1; /* Color de la barra de desplazamiento */
+    border-radius: 10px; /* Estilo redondeado */
+}
 


### PR DESCRIPTION
Se agregó la lógica para limitar la cantidad de nuevas notificaciones mostradas cuando se crea un nuevo evento. Se introdujo la función scrolltoTop(), la cual es llamada cuando se renderizan las notificaciones. También se añadieron los estilos necesarios para mostrar una barra de desplazamiento y limitar el espacio que ocupa la caja de notificaciones.


![Grabación-de-pantalla-2024-10-10-161003](https://github.com/user-attachments/assets/b5354c3d-ff35-4e64-921c-ae621bcdb97c)


