### PR TITLE
fix: phpmail.log permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN curl -L -o /usr/local/bin/phpunit \
   https://phar.phpunit.de/phpunit-11.phar
 
 RUN chmod +x /usr/local/bin/phpunit
+RUN touch /tmp/phpmail.log && chmod 666 /tmp/phpmail.log
 
 # Expone el puerto 80 para el servidor web Apache
 EXPOSE 80


### PR DESCRIPTION
solucion al #49 

para que el Docker ahora al crear el phpmail.log y le da permidos de lectura y escritura 666

![vkxuqbatopk21-3174046785](https://github.com/user-attachments/assets/91654e23-d2ec-443c-9419-d3d2e5950acd)
