### PR TITLE
set google api version

### DIFF
--- a/view/ControlEventos/index.php
+++ b/view/ControlEventos/index.php
@@ -95,7 +95,7 @@ require_once('modalNivelPeligro.php');
 require_once('modalDerivar.php');
 require_once("../MainJs/js.php");
 ?>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAdCMoRAl_-ARUflpa4Jn_qUoOpdXlxQEg&libraries=places"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAdCMoRAl_-ARUflpa4Jn_qUoOpdXlxQEg&libraries=places&v=3.55"></script>
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script type="text/javascript" src="./nivelpeligro.js"></script>

--- a/view/HistorialEventos/index.php
+++ b/view/HistorialEventos/index.php
@@ -101,7 +101,7 @@ Permisos::redirigirSiNoAutorizado();
 
 require_once("../MainJs/js.php");
 ?>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAdCMoRAl_-ARUflpa4Jn_qUoOpdXlxQEg&libraries=places"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAdCMoRAl_-ARUflpa4Jn_qUoOpdXlxQEg&libraries=places&v=3.55"></script>
 </body>
 
 <script type="text/javascript" src="./historialeventos.js"></script>

--- a/view/MapaCalor/index.php
+++ b/view/MapaCalor/index.php
@@ -98,7 +98,7 @@ Permisos::redirigirSiNoAutorizado();
   <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
     <?php require_once("../MainFooter/footer.php"); ?>
     <script
-      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAQrYCFSz7Q-a-WONxo4yymu9SAPgmaA6c&callback=initMap&libraries=visualization,places&v=weekly&loading=async"
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAQrYCFSz7Q-a-WONxo4yymu9SAPgmaA6c&callback=initMap&libraries=visualization,places,marker&v=weekly&loading=async&v=3.55"
       defer
     ></script>
 </body>

--- a/view/NuevoEvento/index.php
+++ b/view/NuevoEvento/index.php
@@ -10,7 +10,7 @@ if (isset($_SESSION["usu_id"])) {
 
 <link rel="stylesheet" href="./estilopersonal.css">
 <title>Sistema Emergencia</title>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAQrYCFSz7Q-a-WONxo4yymu9SAPgmaA6c&libraries=places&callback=initMap"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAQrYCFSz7Q-a-WONxo4yymu9SAPgmaA6c&libraries=places,marker&v=3.55"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 


### PR DESCRIPTION
Este commit actualiza la integración de Google Maps API, especificando la versión 3.55 en la URL de carga. Antes, la URL no incluía una versión fija, lo cual causaba advertencias de métodos deprecated en el uso de marcadores (Markers) debido a cambios en versiones más recientes de la API.

- Fija la URL de Google Maps API a v=3.55 para mejorar la estabilidad.
- Elimina advertencias de deprecated y asegura compatibilidad en el manejo de marcadores.

Closes #71
